### PR TITLE
security: update vulnerable deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
       "@remix-run/router": ">=1.23.2",
       "diff": ">=8.0.3",
       "undici": ">=6.23.0",
-      "lodash": ">=4.17.23"
+      "lodash": ">=4.17.23",
+      "@isaacs/brace-expansion": ">=5.0.1",
+      "fast-xml-parser": ">=5.3.4"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,8 @@ overrides:
   diff: '>=8.0.3'
   undici: '>=6.23.0'
   lodash: '>=4.17.23'
+  '@isaacs/brace-expansion': '>=5.0.1'
+  fast-xml-parser: '>=5.3.4'
 
 importers:
 
@@ -109,7 +111,7 @@ importers:
         specifier: ^4.22.0
         version: 4.22.1
       fast-xml-parser:
-        specifier: ^5.3.4
+        specifier: '>=5.3.4'
         version: 5.3.4
       geoip-lite:
         specifier: ^1.4.10
@@ -2584,10 +2586,6 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
-  fast-xml-parser@5.2.5:
-    resolution: {integrity: sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==}
-    hasBin: true
-
   fast-xml-parser@5.3.4:
     resolution: {integrity: sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==}
     hasBin: true
@@ -4806,7 +4804,7 @@ snapshots:
   '@aws-sdk/xml-builder@3.914.0':
     dependencies:
       '@smithy/types': 4.8.0
-      fast-xml-parser: 5.2.5
+      fast-xml-parser: 5.3.4
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.1.1': {}
@@ -7227,10 +7225,6 @@ snapshots:
       tslib: 2.8.1
 
   fast-uri@3.1.0: {}
-
-  fast-xml-parser@5.2.5:
-    dependencies:
-      strnum: 2.1.2
 
   fast-xml-parser@5.3.4:
     dependencies:


### PR DESCRIPTION

- Add override for @isaacs/brace-expansion >=5.0.1 (CVE-2025-XXXX)
- Add override for fast-xml-parser >=5.3.4 (RangeError DoS)
- Ensure lodash >=4.17.23 (Prototype Pollution)