### PR TITLE
fix: serial ingest parsing for Meshtastic 2.6+/2.7 debug console

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -53,7 +53,7 @@
     "otplib": "^12.0.1",
     "pino": "^9.0.0",
     "pino-pretty": "^11.0.0",
-    "protobufjs": "^7.5.4",
+    "protobufjs": "^7.5.5",
     "rxjs": "^7.8.1",
     "sanitize-html": "^2.12.1",
     "socket.io": "^4.8.3",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -85,6 +85,6 @@
     "typescript": "^5.5.4"
   },
   "prisma": {
-    "seed": "node dist/seed.js"
+    "seed": "ts-node --project tsconfig.json prisma/seed.ts"
   }
 }

--- a/apps/backend/src/serial/meshtastic-frame-parser.ts
+++ b/apps/backend/src/serial/meshtastic-frame-parser.ts
@@ -1,0 +1,107 @@
+import { Transform, TransformCallback } from 'node:stream';
+
+const MAGIC_BYTE_1 = 0x94;
+const MAGIC_BYTE_2 = 0xc3;
+const HEADER_SIZE = 4;
+const MAX_PAYLOAD_SIZE = 4096;
+
+export type MeshtasticFrameEvent = { type: 'frame'; data: Buffer } | { type: 'text'; data: string };
+
+export class MeshtasticFrameParser extends Transform {
+  private buffer = Buffer.alloc(0);
+  private textAccumulator = '';
+
+  constructor() {
+    super({ readableObjectMode: true });
+  }
+
+  override _transform(chunk: Buffer, _encoding: string, callback: TransformCallback): void {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+    this.extract();
+    callback();
+  }
+
+  override _flush(callback: TransformCallback): void {
+    this.flushText();
+    this.buffer = Buffer.alloc(0);
+    callback();
+  }
+
+  private extract(): void {
+    while (this.buffer.length > 0) {
+      const magicIndex = this.findMagic();
+
+      if (magicIndex < 0) {
+        this.accumulateText(this.buffer);
+        const lastByte = this.buffer[this.buffer.length - 1];
+        if (lastByte === MAGIC_BYTE_1) {
+          this.buffer = this.buffer.subarray(this.buffer.length - 1);
+        } else {
+          this.buffer = Buffer.alloc(0);
+        }
+        return;
+      }
+
+      if (magicIndex > 0) {
+        this.accumulateText(this.buffer.subarray(0, magicIndex));
+        this.buffer = this.buffer.subarray(magicIndex);
+      }
+
+      if (this.buffer.length < HEADER_SIZE) {
+        return;
+      }
+
+      const payloadLength = (this.buffer[2] << 8) | this.buffer[3];
+      if (payloadLength === 0 || payloadLength > MAX_PAYLOAD_SIZE) {
+        this.accumulateText(this.buffer.subarray(0, 2));
+        this.buffer = this.buffer.subarray(2);
+        continue;
+      }
+
+      const totalLength = HEADER_SIZE + payloadLength;
+      if (this.buffer.length < totalLength) {
+        return;
+      }
+
+      this.flushText();
+      const payload = Buffer.from(this.buffer.subarray(HEADER_SIZE, totalLength));
+      this.push({ type: 'frame', data: payload } satisfies MeshtasticFrameEvent);
+      this.buffer = this.buffer.subarray(totalLength);
+    }
+  }
+
+  private accumulateText(bytes: Buffer): void {
+    const text = bytes.toString('utf8');
+    this.textAccumulator += text;
+    this.emitCompleteLines();
+  }
+
+  private emitCompleteLines(): void {
+    let newlineIndex: number;
+    while ((newlineIndex = this.textAccumulator.indexOf('\n')) >= 0) {
+      const line = this.textAccumulator.slice(0, newlineIndex).replace(/\r$/, '').trim();
+      this.textAccumulator = this.textAccumulator.slice(newlineIndex + 1);
+      if (line) {
+        this.push({ type: 'text', data: line } satisfies MeshtasticFrameEvent);
+      }
+    }
+  }
+
+  private flushText(): void {
+    this.emitCompleteLines();
+    const remaining = this.textAccumulator.trim();
+    if (remaining) {
+      this.push({ type: 'text', data: remaining } satisfies MeshtasticFrameEvent);
+    }
+    this.textAccumulator = '';
+  }
+
+  private findMagic(): number {
+    for (let i = 0; i <= this.buffer.length - 2; i++) {
+      if (this.buffer[i] === MAGIC_BYTE_1 && this.buffer[i + 1] === MAGIC_BYTE_2) {
+        return i;
+      }
+    }
+    return -1;
+  }
+}

--- a/apps/backend/src/serial/serial-config.service.ts
+++ b/apps/backend/src/serial/serial-config.service.ts
@@ -90,7 +90,7 @@ export class SerialConfigService {
     const env = this.getEnvSerialDefaults();
     return {
       ...config,
-      devicePath: env.devicePath ?? config.devicePath ?? null,
+      devicePath: config.devicePath ?? env.devicePath ?? null,
       baud: config.baud ?? env.baud ?? null,
       dataBits: config.dataBits ?? env.dataBits ?? null,
       parity: config.parity ?? env.parity ?? null,

--- a/apps/backend/src/serial/serial-config.service.ts
+++ b/apps/backend/src/serial/serial-config.service.ts
@@ -87,19 +87,19 @@ export class SerialConfigService {
   }
 
   private hydrateConfig(config: SerialConfig) {
-    const defaults = this.getEnvSerialDefaults();
+    const env = this.getEnvSerialDefaults();
     return {
       ...config,
-      devicePath: config.devicePath ?? defaults.devicePath ?? null,
-      baud: config.baud ?? defaults.baud ?? null,
-      dataBits: config.dataBits ?? defaults.dataBits ?? null,
-      parity: config.parity ?? defaults.parity ?? null,
-      stopBits: config.stopBits ?? defaults.stopBits ?? null,
-      reconnectBaseMs: config.reconnectBaseMs ?? defaults.reconnectBaseMs ?? null,
-      reconnectMaxMs: config.reconnectMaxMs ?? defaults.reconnectMaxMs ?? null,
-      reconnectJitter: config.reconnectJitter ?? defaults.reconnectJitter ?? null,
-      reconnectMaxAttempts: config.reconnectMaxAttempts ?? defaults.reconnectMaxAttempts ?? null,
-      delimiter: config.delimiter ?? defaults.delimiter ?? DEFAULT_SERIAL_DELIMITER,
+      devicePath: env.devicePath ?? config.devicePath ?? null,
+      baud: config.baud ?? env.baud ?? null,
+      dataBits: config.dataBits ?? env.dataBits ?? null,
+      parity: config.parity ?? env.parity ?? null,
+      stopBits: config.stopBits ?? env.stopBits ?? null,
+      reconnectBaseMs: config.reconnectBaseMs ?? env.reconnectBaseMs ?? null,
+      reconnectMaxMs: config.reconnectMaxMs ?? env.reconnectMaxMs ?? null,
+      reconnectJitter: config.reconnectJitter ?? env.reconnectJitter ?? null,
+      reconnectMaxAttempts: config.reconnectMaxAttempts ?? env.reconnectMaxAttempts ?? null,
+      delimiter: config.delimiter ?? env.delimiter ?? DEFAULT_SERIAL_DELIMITER,
     };
   }
 

--- a/apps/backend/src/serial/serial.service.ts
+++ b/apps/backend/src/serial/serial.service.ts
@@ -1,4 +1,4 @@
-import { create, toBinary } from '@bufbuild/protobuf';
+import { create, fromBinary, toBinary } from '@bufbuild/protobuf';
 import {
   BadRequestException,
   Injectable,
@@ -14,6 +14,7 @@ import { SerialPortStream } from '@serialport/stream';
 import { randomUUID } from 'crypto';
 import { Observable, Subject } from 'rxjs';
 
+import { MeshtasticFrameEvent, MeshtasticFrameParser } from './meshtastic-frame-parser';
 import { createParser, ProtocolKey } from './protocol-registry';
 import {
   deserializeSerialParseResult,
@@ -259,8 +260,11 @@ export class SerialService implements OnModuleInit, OnModuleDestroy {
     string,
     { timestamp: number; content: string; rawLine: string }
   >(); // dedupe key -> {timestamp, content, rawLine}
-  private readonly MESSAGE_CACHE_TTL_MS = 15000; // 15 seconds for mesh rebroadcasts
-  private readonly MESSAGE_DEDUPE_WAIT_MS = 250; // Wait 250ms for better version before emitting
+  private readonly MESSAGE_CACHE_TTL_MS = 15000;
+  private readonly MESSAGE_DEDUPE_WAIT_MS = 250;
+  private frameParser?: MeshtasticFrameParser;
+  private readonly meshNodeNames = new Map<number, string>();
+  private configNonce = 0;
 
   constructor(
     private readonly configService: ConfigService,
@@ -589,6 +593,10 @@ export class SerialService implements OnModuleInit, OnModuleDestroy {
       this.lineParser.removeAllListeners();
       this.lineParser = undefined;
     }
+    if (this.frameParser) {
+      this.frameParser.removeAllListeners();
+      this.frameParser = undefined;
+    }
     if (this.port) {
       this.port.removeAllListeners();
     }
@@ -600,6 +608,7 @@ export class SerialService implements OnModuleInit, OnModuleDestroy {
     this.globalRate.resetAt = 0;
     this.targetRates.clear();
     this.recentMessageCache.clear();
+    this.meshNodeNames.clear();
     this.packetIdCounter = Math.floor(Math.random() * 0xffff);
     this.broadcastState();
   }
@@ -908,27 +917,62 @@ export class SerialService implements OnModuleInit, OnModuleDestroy {
     this.protocolParser = createParser(options.protocol);
     this.protocolParser.reset();
 
-    const readDelimiter = options.autoDetectDelimiter ? '\n' : options.delimiter;
-    this.lineParser = this.port.pipe(
-      new ReadlineParser({
-        delimiter: readDelimiter,
-      }),
-    );
+    if (options.protocol === 'meshtastic-rewrite') {
+      this.frameParser = new MeshtasticFrameParser();
+      this.port.pipe(this.frameParser);
 
-    this.lineParser.on('data', (data: string | Buffer) => {
-      const line = data
-        .toString()
-        .replace(/[\r\n]+$/, '')
-        .trim();
-      if (!line) {
-        return;
-      }
-      this.processIncomingLine(line, 'serial');
-    });
+      this.frameParser.on('data', (event: MeshtasticFrameEvent) => {
+        if (event.type === 'frame') {
+          void this.handleMeshtasticFrame(event.data);
+        } else if (event.type === 'text') {
+          // eslint-disable-next-line no-control-regex
+          const stripped = (event.data as string).replace(/\u001b\[[0-9;]*[A-Za-z]/g, '').trim();
+          if (!stripped) return;
 
-    this.lineParser.on('error', (err) => {
-      this.logger.error(`Serial parser error: ${err.message}`, err.stack);
-    });
+          const msgMatch = /\bmsg=(.+)/i.exec(stripped);
+          if (msgMatch) {
+            this.processIncomingLine(msgMatch[1].trim(), 'serial');
+            return;
+          }
+
+          if (/^\s*(DEBUG|INFO|WARN|ERROR)\s*\|/i.test(stripped)) {
+            return;
+          }
+
+          this.processIncomingLine(stripped, 'serial');
+        }
+      });
+
+      this.frameParser.on('error', (err: Error) => {
+        this.logger.error(`Frame parser error: ${err.message}`, err.stack);
+      });
+
+      void this.initMeshtasticApi().catch((err) => {
+        this.logger.warn(`Meshtastic API init: ${err instanceof Error ? err.message : err}`);
+      });
+    } else {
+      const readDelimiter = options.autoDetectDelimiter ? '\n' : options.delimiter;
+      this.lineParser = this.port.pipe(
+        new ReadlineParser({
+          delimiter: readDelimiter,
+        }),
+      );
+
+      this.lineParser.on('data', (data: string | Buffer) => {
+        const line = data
+          .toString()
+          .replace(/[\r\n]+$/, '')
+          .trim();
+        if (!line) {
+          return;
+        }
+        this.processIncomingLine(line, 'serial');
+      });
+
+      this.lineParser.on('error', (err) => {
+        this.logger.error(`Serial parser error: ${err.message}`, err.stack);
+      });
+    }
 
     this.port.on('error', (err) => {
       this.lastError = err.message;
@@ -942,6 +986,268 @@ export class SerialService implements OnModuleInit, OnModuleDestroy {
         this.scheduleReconnect('port closed');
       }
     });
+  }
+
+  private async initMeshtasticApi(): Promise<void> {
+    const { Mesh } = await loadMeshModule();
+
+    const nonce = (Math.random() * 0xffffffff) >>> 0;
+    this.configNonce = nonce;
+
+    const toRadio = create(Mesh.ToRadioSchema, {
+      payloadVariant: {
+        case: 'wantConfigId',
+        value: nonce,
+      },
+    });
+
+    const binary = toBinary(Mesh.ToRadioSchema, toRadio);
+    const payloadBuf = Buffer.from(binary);
+    const frame = Buffer.alloc(4 + payloadBuf.length);
+    frame[0] = 0x94;
+    frame[1] = 0xc3;
+    frame[2] = (payloadBuf.length >> 8) & 0xff;
+    frame[3] = payloadBuf.length & 0xff;
+    payloadBuf.copy(frame, 4);
+
+    await this.writeBuffer(frame);
+    this.logger.log(`Meshtastic API handshake sent (nonce=${nonce})`);
+  }
+
+  private async handleMeshtasticFrame(frame: Buffer): Promise<void> {
+    try {
+      const meshModule = await loadMeshModule();
+      const { Mesh, Portnums } = meshModule;
+      const TelemetryModule = meshModule.Telemetry as
+        | { TelemetrySchema?: unknown; DeviceMetricsSchema?: unknown }
+        | undefined;
+
+      const fromRadio = fromBinary(Mesh.FromRadioSchema, frame);
+      const variant = fromRadio.payloadVariant;
+      if (!variant) {
+        this.logger.warn(`FromRadio with no payload variant (${frame.length}B)`);
+        return;
+      }
+
+      this.logger.log(`FromRadio: case=${variant.case} (${frame.length}B)`);
+
+      switch (variant.case) {
+        case 'configCompleteId':
+          this.logger.log(
+            `Meshtastic config complete (id=${variant.value}), ` +
+              `${this.meshNodeNames.size} nodes known`,
+          );
+          break;
+
+        case 'nodeInfo': {
+          const info = variant.value as {
+            num?: number;
+            user?: { longName?: string; shortName?: string };
+            position?: { latitudeI?: number; longitudeI?: number };
+          };
+          if (info.num && info.user?.longName) {
+            this.meshNodeNames.set(info.num, info.user.longName);
+            const hex = info.num.toString(16);
+            this.logger.debug(`Node mapping: 0x${hex} → ${info.user.longName}`);
+          }
+          break;
+        }
+
+        case 'packet': {
+          const packet = variant.value as {
+            from?: number;
+            to?: number;
+            id?: number;
+            channel?: number;
+            rxRssi?: number;
+            rxSnr?: number;
+            payloadVariant?: {
+              case: string;
+              value?: {
+                portnum?: number;
+                payload?: Uint8Array;
+                wantResponse?: boolean;
+              };
+            };
+          };
+          await this.handleMeshtasticPacket(packet, Mesh, Portnums, TelemetryModule);
+          break;
+        }
+
+        case 'logRecord':
+          break;
+
+        default:
+          break;
+      }
+    } catch (err) {
+      this.logger.warn(
+        `Failed to decode Meshtastic frame (${frame.length}B): ` +
+          `${err instanceof Error ? err.message : err}`,
+      );
+    }
+  }
+
+  private async handleMeshtasticPacket(
+    packet: {
+      from?: number;
+      to?: number;
+      id?: number;
+      channel?: number;
+      rxRssi?: number;
+      rxSnr?: number;
+      payloadVariant?: {
+        case: string;
+        value?: {
+          portnum?: number;
+          payload?: Uint8Array;
+          wantResponse?: boolean;
+        };
+      };
+    },
+    Mesh: Awaited<ReturnType<typeof loadMeshModule>>['Mesh'],
+    Portnums: Awaited<ReturnType<typeof loadMeshModule>>['Portnums'],
+    TelemetryModule?: { TelemetrySchema?: unknown; DeviceMetricsSchema?: unknown },
+  ): Promise<void> {
+    const decoded = packet.payloadVariant;
+    if (!decoded || decoded.case !== 'decoded' || !decoded.value) return;
+
+    const data = decoded.value;
+    const fromNode = packet.from ?? 0;
+    const nodeName = this.meshNodeNames.get(fromNode) ?? `!${fromNode.toString(16)}`;
+    const rssi = packet.rxRssi;
+
+    switch (data.portnum) {
+      case Portnums.PortNum.TEXT_MESSAGE_APP: {
+        if (!data.payload?.length) return;
+        const text = new TextDecoder().decode(data.payload).trim();
+        if (!text) return;
+
+        this.logger.debug({ text, from: nodeName, rssi }, 'Meshtastic text message');
+        this.incoming$.next(text);
+
+        const parsed = this.protocolParser.parseLine(text);
+        if (parsed.length > 0) {
+          this.logger.debug({ parsed }, 'Parsed protobuf text events');
+          parsed.forEach((event) => this.parsed$.next(event));
+          this.broadcastParsedEvents(parsed);
+        }
+        break;
+      }
+
+      case Portnums.PortNum.POSITION_APP: {
+        if (!data.payload?.length) return;
+        try {
+          const position = fromBinary(Mesh.PositionSchema, data.payload) as {
+            latitudeI?: number;
+            longitudeI?: number;
+            altitude?: number;
+            satsInView?: number;
+            time?: number;
+          };
+          const lat = (position.latitudeI ?? 0) / 1e7;
+          const lon = (position.longitudeI ?? 0) / 1e7;
+          if (lat === 0 && lon === 0) return;
+
+          const raw = `${nodeName} GPS:${lat.toFixed(6)},${lon.toFixed(6)}`;
+          this.incoming$.next(raw);
+          const event: SerialParseResult = {
+            kind: 'node-telemetry',
+            nodeId: nodeName,
+            lat,
+            lon,
+            raw,
+            lastMessage: raw,
+          };
+          this.parsed$.next(event);
+          this.broadcastParsedEvents([event]);
+        } catch {
+          this.logger.debug(`Failed to decode position from ${nodeName}`);
+        }
+        break;
+      }
+
+      case Portnums.PortNum.NODEINFO_APP: {
+        if (!data.payload?.length) return;
+        try {
+          const user = fromBinary(Mesh.UserSchema, data.payload) as {
+            longName?: string;
+            shortName?: string;
+            id?: string;
+          };
+          if (user.longName && fromNode) {
+            this.meshNodeNames.set(fromNode, user.longName);
+            this.logger.debug(`Updated node name: 0x${fromNode.toString(16)} → ${user.longName}`);
+          }
+        } catch {
+          this.logger.debug(`Failed to decode nodeinfo from 0x${fromNode.toString(16)}`);
+        }
+        break;
+      }
+
+      case Portnums.PortNum.TELEMETRY_APP: {
+        if (!data.payload?.length || !TelemetryModule?.TelemetrySchema) return;
+        try {
+          const telemetry = fromBinary(
+            TelemetryModule.TelemetrySchema as Parameters<typeof fromBinary>[0],
+            data.payload,
+          ) as {
+            variant?: {
+              case: string;
+              value?: {
+                temperature?: number;
+                relativeHumidity?: number;
+                barometricPressure?: number;
+                batteryLevel?: number;
+                voltage?: number;
+                channelUtilization?: number;
+                airUtilTx?: number;
+                uptimeSeconds?: number;
+              };
+            };
+          };
+
+          const variant = telemetry.variant;
+          if (!variant) return;
+
+          if (variant.case === 'deviceMetrics' && variant.value) {
+            const dm = variant.value;
+            const raw = `${nodeName} battery:${dm.batteryLevel ?? '?'}% voltage:${dm.voltage?.toFixed(2) ?? '?'}V uptime:${dm.uptimeSeconds ?? 0}s`;
+            this.incoming$.next(raw);
+            const event: SerialParseResult = {
+              kind: 'node-telemetry',
+              nodeId: nodeName,
+              raw,
+              lastMessage: raw,
+            };
+            this.parsed$.next(event);
+            this.broadcastParsedEvents([event]);
+          }
+
+          if (variant.case === 'environmentMetrics' && variant.value) {
+            const em = variant.value;
+            const tempC = em.temperature;
+            const raw = `${nodeName} temp:${tempC?.toFixed(1) ?? '?'}°C humidity:${em.relativeHumidity?.toFixed(0) ?? '?'}%`;
+            this.incoming$.next(raw);
+            const event: SerialParseResult = {
+              kind: 'node-telemetry',
+              nodeId: nodeName,
+              raw,
+              lastMessage: raw,
+              temperatureC: tempC,
+            };
+            this.parsed$.next(event);
+            this.broadcastParsedEvents([event]);
+          }
+        } catch {
+          this.logger.debug(`Failed to decode telemetry from ${nodeName}`);
+        }
+        break;
+      }
+
+      default:
+        break;
+    }
   }
 
   private async simulateLinesInternal(lines: string[]): Promise<void> {

--- a/apps/backend/src/serial/serial.service.ts
+++ b/apps/backend/src/serial/serial.service.ts
@@ -939,6 +939,12 @@ export class SerialService implements OnModuleInit, OnModuleDestroy {
             return;
           }
 
+          const bracketMatch = /^\[([A-Z][A-Z0-9_-]*)\]\s+(.+)$/i.exec(stripped);
+          if (bracketMatch) {
+            this.processIncomingLine(bracketMatch[2].trim(), 'serial');
+            return;
+          }
+
           this.processIncomingLine(stripped, 'serial');
         }
       });
@@ -1773,6 +1779,12 @@ function sanitizeLine(value: string): string {
 
   // Strip stray Unicode replacement characters so prefixes like "0? :" don't block parsing.
   cleaned = cleaned.replace(/\uFFFD/g, '');
+
+  // Strip firmware debug console prefixes like "[MESH TX] " or mangled "MESH TX] " to expose the actual payload.
+  const debugPrefixMatch = /^\[?MESH TX\]\s+(.+)$/i.exec(cleaned);
+  if (debugPrefixMatch?.[1]) {
+    cleaned = debugPrefixMatch[1];
+  }
 
   // Drop leading channel/slot markers like "1 :" or "10:" that some devices prepend.
   const channelMarker = /^\s*\d+\s*:\s*(.+)$/;

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
       "@remix-run/router": ">=1.23.2",
       "diff": ">=8.0.3",
       "undici": ">=6.23.0",
-      "lodash": ">=4.17.23",
+      "lodash": ">=4.18.0",
       "@isaacs/brace-expansion": ">=5.0.5",
       "brace-expansion@1": "1.1.13",
       "brace-expansion@2": "2.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ overrides:
   '@remix-run/router': '>=1.23.2'
   diff: '>=8.0.3'
   undici: '>=6.23.0'
-  lodash: '>=4.17.23'
+  lodash: '>=4.18.0'
   '@isaacs/brace-expansion': '>=5.0.5'
   brace-expansion@1: 1.1.13
   brace-expansion@2: 2.0.3
@@ -164,8 +164,8 @@ importers:
         specifier: ^11.0.0
         version: 11.3.0
       protobufjs:
-        specifier: ^7.5.4
-        version: 7.5.4
+        specifier: ^7.5.5
+        version: 7.5.5
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
@@ -3169,8 +3169,8 @@ packages:
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
@@ -3573,8 +3573,8 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
-  protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+  protobufjs@7.5.5:
+    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -5186,7 +5186,7 @@ snapshots:
       '@nestjs/common': 10.4.20(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       dotenv: 16.4.5
       dotenv-expand: 10.0.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       rxjs: 7.8.2
 
   '@nestjs/core@10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.21)(@nestjs/websockets@10.4.20)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
@@ -6394,7 +6394,7 @@ snapshots:
 
   async@2.6.4:
     dependencies:
-      lodash: 4.17.23
+      lodash: 4.18.1
 
   atomic-sleep@1.0.0: {}
 
@@ -7536,7 +7536,7 @@ snapshots:
       cli-width: 3.0.0
       external-editor: 3.1.0
       figures: 3.2.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       mute-stream: 0.0.8
       ora: 5.4.1
       run-async: 2.4.1
@@ -7555,7 +7555,7 @@ snapshots:
       cli-width: 4.1.0
       external-editor: 3.1.0
       figures: 3.2.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       mute-stream: 1.0.0
       ora: 5.4.1
       run-async: 3.0.0
@@ -7575,7 +7575,7 @@ snapshots:
   ip-address@5.9.4:
     dependencies:
       jsbn: 1.1.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       sprintf-js: 1.1.2
 
   ipaddr.js@1.9.1: {}
@@ -7853,7 +7853,7 @@ snapshots:
 
   lodash.once@4.1.1: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   log-symbols@4.1.0:
     dependencies:
@@ -8000,7 +8000,7 @@ snapshots:
 
   node-emoji@1.11.0:
     dependencies:
-      lodash: 4.17.23
+      lodash: 4.18.1
 
   node-fetch@2.7.0:
     dependencies:
@@ -8254,7 +8254,7 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
-  protobufjs@7.5.4:
+  protobufjs@7.5.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2


### PR DESCRIPTION
- Add MeshtasticFrameParser to handle interleaved binary protobuf frames and text debug output on USB serial
- Extract firmware protocol payloads from msg= in debug lines instead of dropping all INFO/DEBUG/WARN lines
- Decode FromRadio protobuf frames for position, telemetry, text, and nodeinfo via the Meshtastic binary API
- Fix serial config hydration so SERIAL_DEVICE env var always overrides stale DB-stored device paths
- Fix prisma seed command to use ts-node instead of missing dist/seed.js