### PR TITLE
fix: system updater

### DIFF
--- a/apps/backend/src/update/update-git.service.ts
+++ b/apps/backend/src/update/update-git.service.ts
@@ -138,6 +138,7 @@ export class UpdateGitService {
       '--porcelain',
       '--left-right',
       '--count',
+      '--verify',
       '--ff-only',
       '--hard',
       '--soft',
@@ -213,6 +214,9 @@ export class UpdateGitService {
   async getCurrentCommit(): Promise<string> {
     try {
       const result = await this.execGit(['rev-parse', 'HEAD']);
+      if (result.exitCode !== 0 || !result.stdout.match(/^[0-9a-f]{40}$/)) {
+        throw new Error(`Could not resolve HEAD: ${result.stderr || 'not a valid commit hash'}`);
+      }
       return result.stdout;
     } catch (error: unknown) {
       const err = error as Error;
@@ -330,12 +334,23 @@ export class UpdateGitService {
     branch: string = 'main',
   ): Promise<{ behind: number; ahead: number }> {
     try {
+      const ref = `${remote}/${branch}`;
+      const verifyResult = await this.execGit(['rev-parse', '--verify', ref]);
+      if (verifyResult.exitCode !== 0) {
+        this.logger.warn(`Remote ref ${ref} does not exist — cannot compare`);
+        return { ahead: 0, behind: 0 };
+      }
+
       const result = await this.execGit([
         'rev-list',
         '--left-right',
         '--count',
-        `HEAD...${remote}/${branch}`,
+        `HEAD...${ref}`,
       ]);
+
+      if (result.exitCode !== 0) {
+        throw new Error(`rev-list failed: ${result.stderr}`);
+      }
 
       const parts = result.stdout.split(/\s+/);
       return {
@@ -355,6 +370,11 @@ export class UpdateGitService {
   async getRemoteCommit(remote: string = 'origin', branch: string = 'main'): Promise<string> {
     try {
       const result = await this.execGit(['rev-parse', `${remote}/${branch}`]);
+      if (result.exitCode !== 0 || !result.stdout.match(/^[0-9a-f]{40}$/)) {
+        throw new Error(
+          `Could not resolve ${remote}/${branch}: ${result.stderr || 'not a valid commit hash'}`,
+        );
+      }
       return result.stdout;
     } catch (error: unknown) {
       const err = error as Error;
@@ -369,15 +389,16 @@ export class UpdateGitService {
   async getRemoteCommitDetails(
     remote: string = 'origin',
     branch: string = 'main',
-  ): Promise<{ message: string; date: string } | null> {
+  ): Promise<{ message: string; date: string; author: string } | null> {
     try {
       const hash = await this.getRemoteCommit(remote, branch);
-      const messageResult = await this.execGit(['log', '-1', '--format=%s', hash]);
-      const dateResult = await this.execGit(['log', '-1', '--format=%aI', hash]);
+      const result = await this.execGit(['log', '-1', '--format=%s%n%aI%n%an', hash]);
+      const lines = result.stdout.split('\n');
 
       return {
-        message: messageResult.stdout,
-        date: dateResult.stdout,
+        message: lines[0] || '',
+        date: lines[1] || '',
+        author: lines[2] || '',
       };
     } catch (error: unknown) {
       const err = error as Error;

--- a/apps/backend/src/update/update-git.service.ts
+++ b/apps/backend/src/update/update-git.service.ts
@@ -341,12 +341,7 @@ export class UpdateGitService {
         return { ahead: 0, behind: 0 };
       }
 
-      const result = await this.execGit([
-        'rev-list',
-        '--left-right',
-        '--count',
-        `HEAD...${ref}`,
-      ]);
+      const result = await this.execGit(['rev-list', '--left-right', '--count', `HEAD...${ref}`]);
 
       if (result.exitCode !== 0) {
         throw new Error(`rev-list failed: ${result.stderr}`);

--- a/apps/backend/src/update/update.controller.ts
+++ b/apps/backend/src/update/update.controller.ts
@@ -56,6 +56,7 @@ export class UpdateController {
         commitsBehind: updateInfo.commitsBehind,
         lastCommitMessage: updateInfo.lastCommitMessage,
         lastCommitDate: updateInfo.lastCommitDate,
+        lastCommitAuthor: updateInfo.lastCommitAuthor,
         lastCheckAt: updateInfo.lastCheckAt,
         canUpdate: updateInfo.available && blockers.length === 0,
         blockers: blockers.length > 0 ? blockers : undefined,

--- a/apps/backend/src/update/update.service.ts
+++ b/apps/backend/src/update/update.service.ts
@@ -147,18 +147,18 @@ export class UpdateService implements OnModuleInit {
         remoteCommitDetails = await this.gitService.getRemoteCommitDetails(remote, branch);
       }
 
+      const remoteCommit = await this.gitService.getRemoteCommit(remote, branch).catch(() => null);
+
       const updateInfo: UpdateInfo = {
         available: status.commitsBehind > 0,
         currentCommit: status.lastCommit?.hash || 'unknown',
         currentBranch: status.currentBranch,
         remote,
-        latestCommit:
-          status.commitsBehind > 0
-            ? await this.gitService.getRemoteCommit(remote, branch)
-            : undefined,
+        latestCommit: remoteCommit || undefined,
         commitsBehind: status.commitsBehind,
         lastCommitMessage: remoteCommitDetails?.message || status.lastCommit?.message,
         lastCommitDate: remoteCommitDetails?.date || status.lastCommit?.date,
+        lastCommitAuthor: remoteCommitDetails?.author || status.lastCommit?.author,
         lastCheckAt: new Date().toISOString(),
         warning: status.networkError,
       };

--- a/apps/backend/src/update/update.types.ts
+++ b/apps/backend/src/update/update.types.ts
@@ -32,6 +32,7 @@ export interface UpdateInfo {
   commitsBehind?: number;
   lastCommitMessage?: string;
   lastCommitDate?: string;
+  lastCommitAuthor?: string;
   lastCheckAt: string;
   error?: string;
   warning?: string;

--- a/apps/frontend/src/pages/ConfigPage.tsx
+++ b/apps/frontend/src/pages/ConfigPage.tsx
@@ -59,6 +59,7 @@ interface UpdateInfo {
   lastCheckAt: string;
   canUpdate: boolean;
   blockers?: string[];
+  warning?: string;
 }
 
 interface UpdateLog {
@@ -4422,13 +4423,7 @@ export function ConfigPage() {
               <>
                 <div className="config-card__body">
                   <div className="config-subcard">
-                    <h3>Current Version</h3>
-                    <div className="config-row">
-                      <span className="config-label">Commit</span>
-                      <span className="mono-text">
-                        {updateInfo?.currentCommit?.substring(0, 8).toUpperCase() || 'Loading...'}
-                      </span>
-                    </div>
+                    <h3>Version Status</h3>
                     <div className="config-row">
                       <span className="config-label">Branch</span>
                       <span className="mono-text">{updateInfo?.currentBranch || 'unknown'}</span>
@@ -4437,6 +4432,99 @@ export function ConfigPage() {
                       <span className="config-label">Remote</span>
                       <span className="mono-text">{updateInfo?.remote || 'origin'}</span>
                     </div>
+                    {(() => {
+                      const localHash =
+                        updateInfo?.currentCommit?.substring(0, 8).toUpperCase() || '--------';
+                      const remoteRaw = updateInfo?.latestCommit || '';
+                      const hasRemoteHash = /^[0-9a-f]{40}$/i.test(remoteRaw);
+                      const remoteHash = hasRemoteHash
+                        ? remoteRaw.substring(0, 8).toUpperCase()
+                        : null;
+                      const hashesMatch = hasRemoteHash && remoteHash === localHash;
+                      const hashesDiffer = hasRemoteHash && remoteHash !== localHash;
+
+                      return (
+                        <div
+                          style={{
+                            display: 'grid',
+                            gridTemplateColumns: hasRemoteHash ? '1fr 1fr' : '1fr',
+                            gap: '0.75rem',
+                            margin: '0.75rem 0',
+                            padding: '0.75rem',
+                            backgroundColor: 'rgba(255, 255, 255, 0.03)',
+                            borderRadius: '4px',
+                            border: '1px solid rgba(255, 255, 255, 0.08)',
+                          }}
+                        >
+                          <div>
+                            <div
+                              style={{
+                                fontSize: '0.75rem',
+                                opacity: 0.6,
+                                marginBottom: '0.25rem',
+                              }}
+                            >
+                              {hasRemoteHash ? 'LOCAL' : 'COMMIT'}
+                            </div>
+                            <span className="mono-text" style={{ fontSize: '0.95rem' }}>
+                              {localHash}
+                            </span>
+                          </div>
+                          {hasRemoteHash && (
+                            <div>
+                              <div
+                                style={{
+                                  fontSize: '0.75rem',
+                                  opacity: 0.6,
+                                  marginBottom: '0.25rem',
+                                }}
+                              >
+                                REMOTE
+                              </div>
+                              <span
+                                className="mono-text"
+                                style={{
+                                  fontSize: '0.95rem',
+                                  color: hashesDiffer ? '#f59e0b' : undefined,
+                                }}
+                              >
+                                {remoteHash}
+                              </span>
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })()}
+                    {(() => {
+                      const remoteRaw = updateInfo?.latestCommit || '';
+                      const hasRemoteHash = /^[0-9a-f]{40}$/i.test(remoteRaw);
+                      if (
+                        hasRemoteHash &&
+                        updateInfo?.currentCommit &&
+                        updateInfo.currentCommit === remoteRaw
+                      ) {
+                        return (
+                          <div
+                            style={{
+                              fontSize: '0.8rem',
+                              color: '#22c55e',
+                              marginBottom: '0.5rem',
+                            }}
+                          >
+                            Hashes match — confirmed up to date
+                          </div>
+                        );
+                      }
+                      return null;
+                    })()}
+                    {updateInfo?.warning && (
+                      <div
+                        className="form-error"
+                        style={{ marginBottom: '0.75rem', fontSize: '0.85rem' }}
+                      >
+                        {updateInfo.warning}
+                      </div>
+                    )}
                     <div className="config-row">
                       <span className="config-label">Last Check</span>
                       <span>{updateInfo ? formatDate(updateInfo.lastCheckAt) : 'Never'}</span>


### PR DESCRIPTION
Frontend — validates latestCommit against hex SHA regex client-side too. When no valid remote hash exists (like now on fix-serial-2), it shows a single COMMIT column with just the local hash. The two-column LOCAL/REMOTE comparison only appears when there's a real remote hash to compare against.

`getRemoteCommit` — now validates exit code AND that stdout matches /^[0-9a-f]{40}$/ before returning. Throws on garbage.

`getCurrentCommit` — same SHA validation added.

`getCommitsDiff` — now verifies the remote ref exists before comparing. Previously would silently return { behind: 0, ahead: 0 } when the ref was invalid, making you think you're up-to-date when it just couldn't check.

